### PR TITLE
Fixed 'inline' for older version of Visual Studio.

### DIFF
--- a/src/libjasper/include/jasper/jas_config2.h
+++ b/src/libjasper/include/jasper/jas_config2.h
@@ -86,4 +86,9 @@
 #define	HAVE_STDLIB_H		1
 #define	HAVE_STDDEF_H		1
 
+#ifndef __cplusplus
+#undef inline
+#define inline __inline
+#endif
+
 #endif


### PR DESCRIPTION
The file jas_malloc.c uses the keyword 'inline' that is not supported by older version of Visual Studio. This patch resolves that issue. If I understand it correctly the file jas_config2.h is used under Windows only. I can also add a check for '_MSC_VER' if you prefer that.