### PR TITLE
Fix multiple printf format specifiers, comment out unused variables

### DIFF
--- a/src/appl/jasper.c
+++ b/src/appl/jasper.c
@@ -300,7 +300,7 @@ int main(int argc, char **argv)
 cmdopts_t *cmdopts_parse(int argc, char **argv)
 {
 
-	typedef enum {
+	enum cmdoptid_t {
 		CMDOPT_HELP = 0,
 		CMDOPT_VERBOSE,
 		CMDOPT_INFILE,
@@ -313,7 +313,7 @@ cmdopts_t *cmdopts_parse(int argc, char **argv)
 		CMDOPT_DEBUG,
 		CMDOPT_CMPTNO,
 		CMDOPT_SRGB
-	} cmdoptid_t;
+	};
 
 	static jas_opt_t cmdoptions[] = {
 		{CMDOPT_HELP, "help", 0},

--- a/src/appl/jiv.c
+++ b/src/appl/jiv.c
@@ -67,6 +67,7 @@
 #include <GL/glut.h>
 #include <stdlib.h>
 #include <math.h>
+#include <inttypes.h>
 
 /******************************************************************************\
 *
@@ -168,7 +169,7 @@ static int jas_image_render(jas_image_t *image, float vtlx, float vtly,
 
 static void dumpstate(void);
 static int pixmap_resize(pixmap_t *p, int w, int h);
-static void pixmap_clear(pixmap_t *p);
+// static void pixmap_clear(pixmap_t *p);
 static void cmdinfo(void);
 
 static void cleanupandexit(int);
@@ -333,8 +334,8 @@ static void displayfunc()
 	int regbotlefty;
 	int regtoprightx;
 	int regtoprighty;
-	int regtoprightwidth;
-	int regtoprightheight;
+	// int regtoprightwidth;
+	// int regtoprightheight;
 	int regwidth;
 	int regheight;
 	float x;
@@ -691,10 +692,10 @@ static void previmage()
 
 static int loadimage()
 {
-	int reshapeflag;
+	// int reshapeflag;
 	jas_stream_t *in;
-	int scrnwidth;
-	int scrnheight;
+	// int scrnwidth;
+	// int scrnheight;
 	int vh;
 	int vw;
 	char *pathname;
@@ -763,7 +764,7 @@ static int loadimage()
 
 	if (cmdopts.verbose) {
 		fprintf(stderr, "num of components %d\n", jas_image_numcmpts(gs.image));
-		fprintf(stderr, "dimensions %d %d\n", jas_image_width(gs.image), jas_image_height(gs.image));
+		fprintf(stderr, "dimensions %" PRIiFAST32 " %" PRIiFAST32 "\n", jas_image_width(gs.image), jas_image_height(gs.image));
 	}
 
 	gs.viewportwidth = vw;
@@ -822,10 +823,12 @@ static void unloadimage()
 *
 \******************************************************************************/
 
+/*
 static void pixmap_clear(pixmap_t *p)
 {
 	memset(p->data, 0, 4 * p->width * p->height * sizeof(GLshort));
 }
+*/
 
 static int pixmap_resize(pixmap_t *p, int w, int h)
 {
@@ -954,11 +957,13 @@ error:
 
 static void render()
 {
+/*
 	float vtlx;
 	float vtly;
 
 	vtlx = gs.botleftx;
 	vtly = gs.toprighty;
+*/
 	if (cmdopts.verbose) {
 //		fprintf(stderr, "vtlx=%f, vtly=%f, vsx=%f, vsy=%f\n",
 //		  vtlx, vtly, gs.sx, gs.sy);

--- a/src/libjasper/base/jas_debug.c
+++ b/src/libjasper/base/jas_debug.c
@@ -125,7 +125,7 @@ int jas_memdump(FILE *out, void *data, size_t len)
 	uchar *dp;
 	dp = data;
 	for (i = 0; i < len; i += 16) {
-		fprintf(out, "%04x:", i);
+		fprintf(out, "%04zu:", i);
 		for (j = 0; j < 16; ++j) {
 			if (i + j < len) {
 				fprintf(out, " %02x", dp[i + j]);

--- a/src/libjasper/base/jas_getopt.c
+++ b/src/libjasper/base/jas_getopt.c
@@ -76,6 +76,7 @@
 
 #include "jasper/jas_getopt.h"
 #include "jasper/jas_math.h"
+#include "jasper/jas_debug.h"
 
 /******************************************************************************\
 * Global data.

--- a/src/libjasper/base/jas_icc.c
+++ b/src/libjasper/base/jas_icc.c
@@ -71,6 +71,7 @@
 
 #include <stdlib.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #define	jas_iccputuint8(out, val)	jas_iccputuint(out, 1, val)
 #define	jas_iccputuint16(out, val)	jas_iccputuint(out, 2, val)
@@ -727,7 +728,7 @@ void jas_iccattrtab_dump(jas_iccattrtab_t *attrtab, FILE *out)
 		attrval = attr->val;
 		info = jas_iccattrvalinfo_lookup(attrval->type);
 		if (!info) abort();
-		fprintf(out, "attrno=%d; attrname=\"%s\"(0x%08x); attrtype=\"%s\"(0x%08x)\n",
+		fprintf(out, "attrno=%d; attrname=\"%s\"(0x%08" PRIuFAST32 "); attrtype=\"%s\"(0x%08" PRIuFAST32 ")\n",
 		  i,
 		  jas_iccsigtostr(attr->name, &buf[0]),
 		  attr->name,
@@ -884,7 +885,7 @@ void jas_iccattrval_dump(jas_iccattrval_t *attrval, FILE *out)
 {
 	char buf[8];
 	jas_iccsigtostr(attrval->type, buf);
-	fprintf(out, "refcnt = %d; type = 0x%08x %s\n", attrval->refcnt,
+	fprintf(out, "refcnt = %d; type = 0x%08" PRIuFAST32 " %s\n", attrval->refcnt,
 	  attrval->type, jas_iccsigtostr(attrval->type, &buf[0]));
 	if (attrval->ops->dump) {
 		(*attrval->ops->dump)(attrval, out);
@@ -1044,7 +1045,7 @@ static void jas_icccurv_dump(jas_iccattrval_t *attrval, FILE *out)
 {
 	int i;
 	jas_icccurv_t *curv = &attrval->data.curv;
-	fprintf(out, "number of entires = %d\n", curv->numents);
+	fprintf(out, "number of entires = %" PRIuFAST32 "\n", curv->numents);
 	if (curv->numents == 1) {
 		fprintf(out, "gamma = %f\n", curv->ents[0] / 256.0);
 	} else {
@@ -1174,9 +1175,9 @@ static void jas_icctxtdesc_dump(jas_iccattrval_t *attrval, FILE *out)
 {
 	jas_icctxtdesc_t *txtdesc = &attrval->data.txtdesc;
 	fprintf(out, "ascii = \"%s\"\n", txtdesc->ascdata);
-	fprintf(out, "uclangcode = %d; uclen = %d\n", txtdesc->uclangcode,
+	fprintf(out, "uclangcode = %" PRIuFAST32 "; uclen = %" PRIuFAST32 "\n", txtdesc->uclangcode,
 	  txtdesc->uclen);
-	fprintf(out, "sccode = %d\n", txtdesc->sccode);
+	fprintf(out, "sccode = %" PRIuFAST16 "\n", txtdesc->sccode);
 	fprintf(out, "maclen = %d\n", txtdesc->maclen);
 }
 
@@ -1418,7 +1419,7 @@ static void jas_icclut8_dump(jas_iccattrval_t *attrval, FILE *out)
 		}
 		fprintf(out, "\n");
 	}
-	fprintf(out, "numintabents=%d, numouttabents=%d\n",
+	fprintf(out, "numintabents=%" PRIuFAST16 ", numouttabents=%" PRIuFAST16 "\n",
 	  lut8->numintabents, lut8->numouttabents);
 }
 
@@ -1592,7 +1593,7 @@ static void jas_icclut16_dump(jas_iccattrval_t *attrval, FILE *out)
 		}
 		fprintf(out, "\n");
 	}
-	fprintf(out, "numintabents=%d, numouttabents=%d\n",
+	fprintf(out, "numintabents=%" PRIuFAST16 ", numouttabents=%" PRIuFAST16 "\n",
 	  lut16->numintabents, lut16->numouttabents);
 }
 

--- a/src/libjasper/base/jas_image.c
+++ b/src/libjasper/base/jas_image.c
@@ -76,6 +76,7 @@
 #include <string.h>
 #include <assert.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include "jasper/jas_math.h"
 #include "jasper/jas_image.h"
@@ -850,7 +851,7 @@ void jas_image_dump(jas_image_t *image, FILE *out)
 	jas_image_cmpt_t *cmpt;
 	for (cmptno = 0; cmptno < image->numcmpts_; ++cmptno) {
 		cmpt = image->cmpts_[cmptno];
-		fprintf(out, "prec=%d, sgnd=%d, cmpttype=%d\n", cmpt->prec_,
+		fprintf(out, "prec=%d, sgnd=%d, cmpttype=%" PRIiFAST32 "\n", cmpt->prec_,
 		  cmpt->sgnd_, cmpt->type_);
 		width = jas_image_cmptwidth(image, cmptno);
 		height = jas_image_cmptheight(image, cmptno);
@@ -1308,14 +1309,14 @@ jas_image_t *jas_image_chclrspc(jas_image_t *image, jas_cmprof_t *outprof,
 	int n;
 	int hstep;
 	int vstep;
-	int numinauxchans;
-	int numoutauxchans;
+	// int numinauxchans;
+	// int numoutauxchans;
 	int numinclrchans;
 	int numoutclrchans;
 	int prec;
 	jas_image_t *outimage;
 	int cmpttype;
-	int numoutchans;
+	// int numoutchans;
 	jas_cmprof_t *inprof;
 	jas_cmprof_t *tmpprof;
 	jas_image_cmptparm_t cmptparm;
@@ -1365,10 +1366,10 @@ jas_image_dump(image, stderr);
 	inprof = jas_image_cmprof(inimage);
 	assert(inprof);
 	numinclrchans = jas_clrspc_numchans(jas_cmprof_clrspc(inprof));
-	numinauxchans = jas_image_numcmpts(inimage) - numinclrchans;
+	// numinauxchans = jas_image_numcmpts(inimage) - numinclrchans;
 	numoutclrchans = jas_clrspc_numchans(jas_cmprof_clrspc(outprof));
-	numoutauxchans = 0;
-	numoutchans = numoutclrchans + numoutauxchans;
+	// numoutauxchans = 0;
+	// numoutchans = numoutclrchans + numoutauxchans;
 	prec = 8;
 
 	if (!(outimage = jas_image_create0()))

--- a/src/libjasper/base/jas_seq.c
+++ b/src/libjasper/base/jas_seq.c
@@ -74,6 +74,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <math.h>
+#include <inttypes.h>
 
 #include "jasper/jas_seq.h"
 #include "jasper/jas_malloc.h"
@@ -448,9 +449,9 @@ int jas_seq2d_output(jas_matrix_t *matrix, FILE *out)
 	char sbuf[MAXLINELEN + 1];
 	int n;
 
-	fprintf(out, "%d %d\n", jas_seq2d_xstart(matrix),
+	fprintf(out, "%" PRIiFAST32 " %" PRIiFAST32 "\n", jas_seq2d_xstart(matrix),
 	  jas_seq2d_ystart(matrix));
-	fprintf(out, "%d %d\n", jas_matrix_numcols(matrix),
+	fprintf(out, "%" PRIiFAST32 " %" PRIiFAST32 "\n", jas_matrix_numcols(matrix),
 	  jas_matrix_numrows(matrix));
 
 	buf[0] = '\0';

--- a/src/libjasper/jp2/jp2_cod.c
+++ b/src/libjasper/jp2/jp2_cod.c
@@ -73,6 +73,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #include "jasper/jas_stream.h"
 #include "jasper/jas_malloc.h"
@@ -319,7 +320,7 @@ void jp2_box_dump(jp2_box_t *box, FILE *out)
 	assert(boxinfo);
 
 	fprintf(out, "JP2 box: ");
-	fprintf(out, "type=%c%s%c (0x%08x); length=%d\n", '"', boxinfo->name,
+	fprintf(out, "type=%c%s%c (0x%08" PRIuFAST32 "); length=%" PRIuFAST32 "\n", '"', boxinfo->name,
 	  '"', box->type, box->len);
 	if (box->ops->dumpdata) {
 		(*box->ops->dumpdata)(box, out);
@@ -431,7 +432,7 @@ static void jp2_cdef_dumpdata(jp2_box_t *box, FILE *out)
 	jp2_cdef_t *cdef = &box->data.cdef;
 	unsigned int i;
 	for (i = 0; i < cdef->numchans; ++i) {
-		fprintf(out, "channo=%d; type=%d; assoc=%d\n",
+		fprintf(out, "channo=%" PRIuFAST16 "; type=%" PRIuFAST16 "; assoc=%" PRIuFAST16 "\n",
 		  cdef->ents[i].channo, cdef->ents[i].type, cdef->ents[i].assoc);
 	}
 }
@@ -871,7 +872,7 @@ static void jp2_pclr_dumpdata(jp2_box_t *box, FILE *out)
 	  (int) pclr->numchans);
 	for (i = 0; i < pclr->numlutents; ++i) {
 		for (j = 0; j < pclr->numchans; ++j) {
-			fprintf(out, "LUT[%d][%d]=%d\n", i, j, pclr->lutdata[i * pclr->numchans + j]);
+			fprintf(out, "LUT[%d][%d]=%" PRIiFAST32 "\n", i, j, pclr->lutdata[i * pclr->numchans + j]);
 		}
 	}
 }

--- a/src/libjasper/jp2/jp2_dec.c
+++ b/src/libjasper/jp2/jp2_dec.c
@@ -104,7 +104,7 @@ jas_image_t *jp2_decode(jas_stream_t *in, char *optstr)
 	unsigned int i;
 	jp2_cmap_t *cmapd;
 	jp2_pclr_t *pclrd;
-	jp2_cdef_t *cdefd;
+	// jp2_cdef_t *cdefd;
 	unsigned int channo;
 	int newcmptno;
 	int_fast32_t *lutents;
@@ -351,7 +351,7 @@ jas_image_t *jp2_decode(jas_stream_t *in, char *optstr)
 	} else {
 		cmapd = &dec->cmap->data.cmap;
 		pclrd = &dec->pclr->data.pclr;
-		cdefd = &dec->cdef->data.cdef;
+		// cdefd = &dec->cdef->data.cdef;
 		for (channo = 0; channo < cmapd->numchans; ++channo) {
 			cmapent = &cmapd->ents[channo];
 			if (cmapent->map == JP2_CMAP_DIRECT) {

--- a/src/libjasper/jpc/jpc_cs.c
+++ b/src/libjasper/jpc/jpc_cs.c
@@ -74,6 +74,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include "jasper/jas_malloc.h"
 #include "jasper/jas_debug.h"
@@ -404,9 +405,9 @@ void jpc_ms_dump(jpc_ms_t *ms, FILE *out)
 {
 	jpc_mstabent_t *mstabent;
 	mstabent = jpc_mstab_lookup(ms->id);
-	fprintf(out, "type = 0x%04x (%s);", ms->id, mstabent->name);
+	fprintf(out, "type = 0x%04" PRIuFAST16 " (%s);", ms->id, mstabent->name);
 	if (JPC_MS_HASPARMS(ms->id)) {
-		fprintf(out, " len = %d;", ms->len + 2);
+		fprintf(out, " len = %" PRIuFAST16 ";", ms->len + 2);
 		if (ms->ops->dumpparms) {
 			(*ms->ops->dumpparms)(ms, out);
 		} else {
@@ -463,7 +464,7 @@ static int jpc_sot_putparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *ou
 static int jpc_sot_dumpparms(jpc_ms_t *ms, FILE *out)
 {
 	jpc_sot_t *sot = &ms->parms.sot;
-	fprintf(out, "tileno = %d; len = %d; partno = %d; numparts = %d\n",
+	fprintf(out, "tileno = %" PRIuFAST16 "; len = %" PRIuFAST32 "; partno = %d; numparts = %d\n",
 	  sot->tileno, sot->len, sot->partno, sot->numparts);
 	return 0;
 }
@@ -573,13 +574,13 @@ static int jpc_siz_dumpparms(jpc_ms_t *ms, FILE *out)
 {
 	jpc_siz_t *siz = &ms->parms.siz;
 	unsigned int i;
-	fprintf(out, "caps = 0x%02x;\n", siz->caps);
-	fprintf(out, "width = %d; height = %d; xoff = %d; yoff = %d;\n",
+	fprintf(out, "caps = 0x%02" PRIuFAST16 ";\n", siz->caps);
+	fprintf(out, "width = %" PRIuFAST32 "; height = %" PRIuFAST32 "; xoff = %" PRIuFAST32 "; yoff = %" PRIuFAST32 ";\n",
 	  siz->width, siz->height, siz->xoff, siz->yoff);
-	fprintf(out, "tilewidth = %d; tileheight = %d; tilexoff = %d; "
-	  "tileyoff = %d;\n", siz->tilewidth, siz->tileheight, siz->tilexoff,
+	fprintf(out, "tilewidth = %" PRIuFAST32 "; tileheight = %" PRIuFAST32 "; tilexoff = %" PRIuFAST32 "; "
+	  "tileyoff = %" PRIuFAST32 ";\n", siz->tilewidth, siz->tileheight, siz->tilexoff,
 	  siz->tileyoff);
-	fprintf(out, "numcomps = %d;\n", siz->numcomps);
+	fprintf(out, "numcomps = %" PRIuFAST16 ";\n", siz->numcomps);
 	for (i = 0; i < siz->numcomps; ++i) {
 		fprintf(out, "prec[%d] = %d; sgnd[%d] = %d; hsamp[%d] = %d; "
 		  "vsamp[%d] = %d\n", i, siz->comps[i].prec, i,
@@ -649,7 +650,7 @@ static int jpc_cod_dumpparms(jpc_ms_t *ms, FILE *out)
 	fprintf(out, "csty = 0x%02x;\n", cod->compparms.csty);
 	fprintf(out, "numdlvls = %d; qmfbid = %d; mctrans = %d\n",
 	  cod->compparms.numdlvls, cod->compparms.qmfbid, cod->mctrans);
-	fprintf(out, "prg = %d; numlyrs = %d;\n",
+	fprintf(out, "prg = %d; numlyrs = %" PRIuFAST16 ";\n",
 	  cod->prg, cod->numlyrs);
 	fprintf(out, "cblkwidthval = %d; cblkheightval = %d; "
 	  "cblksty = 0x%02x;\n", cod->compparms.cblkwidthval, cod->compparms.cblkheightval,
@@ -727,7 +728,7 @@ static int jpc_coc_putparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *ou
 static int jpc_coc_dumpparms(jpc_ms_t *ms, FILE *out)
 {
 	jpc_coc_t *coc = &ms->parms.coc;
-	fprintf(out, "compno = %d; csty = 0x%02x; numdlvls = %d;\n",
+	fprintf(out, "compno = %" PRIuFAST16 "; csty = 0x%02x; numdlvls = %d;\n",
 	  coc->compno, coc->compparms.csty, coc->compparms.numdlvls);
 	fprintf(out, "cblkwidthval = %d; cblkheightval = %d; "
 	  "cblksty = 0x%02x; qmfbid = %d;\n", coc->compparms.cblkwidthval,
@@ -867,7 +868,7 @@ static int jpc_rgn_putparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *ou
 static int jpc_rgn_dumpparms(jpc_ms_t *ms, FILE *out)
 {
 	jpc_rgn_t *rgn = &ms->parms.rgn;
-	fprintf(out, "compno = %d; roisty = %d; roishift = %d\n",
+	fprintf(out, "compno = %" PRIuFAST16 "; roisty = %d; roishift = %d\n",
 	  rgn->compno, rgn->roisty, rgn->roishift);
 	return 0;
 }
@@ -968,7 +969,7 @@ static int jpc_qcc_dumpparms(jpc_ms_t *ms, FILE *out)
 {
 	jpc_qcc_t *qcc = &ms->parms.qcc;
 	int i;
-	fprintf(out, "compno = %d; qntsty = %d; numguard = %d; "
+	fprintf(out, "compno = %" PRIuFAST16 "; qntsty = %d; numguard = %d; "
 	  "numstepsizes = %d\n", qcc->compno, qcc->compparms.qntsty, qcc->compparms.numguard,
 	  qcc->compparms.numstepsizes);
 	for (i = 0; i < qcc->compparms.numstepsizes; ++i) {
@@ -1108,7 +1109,7 @@ static int jpc_sop_putparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *ou
 static int jpc_sop_dumpparms(jpc_ms_t *ms, FILE *out)
 {
 	jpc_sop_t *sop = &ms->parms.sop;
-	fprintf(out, "seqno = %d;\n", sop->seqno);
+	fprintf(out, "seqno = %" PRIuFAST16 ";\n", sop->seqno);
 	return 0;
 }
 
@@ -1174,7 +1175,7 @@ static int jpc_ppm_putparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *ou
 static int jpc_ppm_dumpparms(jpc_ms_t *ms, FILE *out)
 {
 	jpc_ppm_t *ppm = &ms->parms.ppm;
-	fprintf(out, "ind=%d; len = %d;\n", ppm->ind, ppm->len);
+	fprintf(out, "ind=%d; len = %" PRIuFAST16 ";\n", ppm->ind, ppm->len);
 	if (ppm->len > 0) {
 		fprintf(out, "data =\n");
 		jas_memdump(out, ppm->data, ppm->len);
@@ -1246,7 +1247,7 @@ static int jpc_ppt_putparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *ou
 static int jpc_ppt_dumpparms(jpc_ms_t *ms, FILE *out)
 {
 	jpc_ppt_t *ppt = &ms->parms.ppt;
-	fprintf(out, "ind=%d; len = %d;\n", ppt->ind, ppt->len);
+	fprintf(out, "ind=%d; len = %" PRIuFAST32 ";\n", ppt->ind, ppt->len);
 	if (ppt->len > 0) {
 		fprintf(out, "data =\n");
 		jas_memdump(out, ppt->data, ppt->len);
@@ -1352,11 +1353,11 @@ static int jpc_poc_dumpparms(jpc_ms_t *ms, FILE *out)
 	for (pchgno = 0, pchg = poc->pchgs; pchgno < poc->numpchgs;
 	  ++pchgno, ++pchg) {
 		fprintf(out, "po[%d] = %d; ", pchgno, pchg->prgord);
-		fprintf(out, "cs[%d] = %d; ce[%d] = %d; ",
+		fprintf(out, "cs[%d] = %" PRIuFAST16 "; ce[%d] = %" PRIuFAST16 "; ",
 		  pchgno, pchg->compnostart, pchgno, pchg->compnoend);
 		fprintf(out, "rs[%d] = %d; re[%d] = %d; ",
 		  pchgno, pchg->rlvlnostart, pchgno, pchg->rlvlnoend);
-		fprintf(out, "le[%d] = %d\n", pchgno, pchg->lyrnoend);
+		fprintf(out, "le[%d] = %" PRIuFAST16 "\n", pchgno, pchg->lyrnoend);
 	}
 	return 0;
 }
@@ -1419,7 +1420,7 @@ static int jpc_crg_dumpparms(jpc_ms_t *ms, FILE *out)
 	jpc_crgcomp_t *comp;
 	for (compno = 0, comp = crg->comps; compno < crg->numcomps; ++compno,
 	  ++comp) {
-		fprintf(out, "hoff[%d] = %d; voff[%d] = %d\n", compno,
+		fprintf(out, "hoff[%d] = %" PRIuFAST16 "; voff[%d] = %" PRIuFAST16 "\n", compno,
 		  comp->hoff, compno, comp->voff);
 	}
 	return 0;
@@ -1482,7 +1483,7 @@ static int jpc_com_dumpparms(jpc_ms_t *ms, FILE *out)
 	jpc_com_t *com = &ms->parms.com;
 	unsigned int i;
 	int printable;
-	fprintf(out, "regid = %d;\n", com->regid);
+	fprintf(out, "regid = %" PRIuFAST16 ";\n", com->regid);
 	printable = 1;
 	for (i = 0; i < com->len; ++i) {
 		if (!isprint(com->data[i])) {

--- a/src/libjasper/jpc/jpc_dec.c
+++ b/src/libjasper/jpc/jpc_dec.c
@@ -72,6 +72,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <inttypes.h>
 
 #include "jasper/jas_types.h"
 #include "jasper/jas_math.h"
@@ -411,9 +412,11 @@ static int jpc_dec_process_crg(jpc_dec_t *dec, jpc_ms_t *ms)
 {
 	int cmptno;
 	jpc_dec_cmpt_t *cmpt;
+	/*
 	jpc_crg_t *crg;
 
 	crg = &ms->parms.crg;
+	*/
 	for (cmptno = 0, cmpt = dec->cmpts; cmptno < dec->numcomps; ++cmptno,
 	  ++cmpt) {
 		/* Ignore the information in the CRG marker segment for now.
@@ -659,7 +662,7 @@ static int jpc_dec_tileinit(jpc_dec_t *dec, jpc_dec_tile_t *tile)
 	uint_fast32_t tlcbgxstart;
 	uint_fast32_t tlcbgystart;
 	uint_fast32_t brcbgxend;
-	uint_fast32_t brcbgyend;
+	// uint_fast32_t brcbgyend;
 	uint_fast32_t cbgxstart;
 	uint_fast32_t cbgystart;
 	uint_fast32_t cbgxend;
@@ -752,14 +755,14 @@ static int jpc_dec_tileinit(jpc_dec_t *dec, jpc_dec_tile_t *tile)
 				tlcbgxstart = tlprcxstart;
 				tlcbgystart = tlprcystart;
 				brcbgxend = brprcxend;
-				brcbgyend = brprcyend;
+				// brcbgyend = brprcyend;
 				rlvl->cbgwidthexpn = rlvl->prcwidthexpn;
 				rlvl->cbgheightexpn = rlvl->prcheightexpn;
 			} else {
 				tlcbgxstart = JPC_CEILDIVPOW2(tlprcxstart, 1);
 				tlcbgystart = JPC_CEILDIVPOW2(tlprcystart, 1);
 				brcbgxend = JPC_CEILDIVPOW2(brprcxend, 1);
-				brcbgyend = JPC_CEILDIVPOW2(brprcyend, 1);
+				// brcbgyend = JPC_CEILDIVPOW2(brprcyend, 1);
 				rlvl->cbgwidthexpn = rlvl->prcwidthexpn - 1;
 				rlvl->cbgheightexpn = rlvl->prcheightexpn - 1;
 			}
@@ -2037,13 +2040,13 @@ static int jpc_dec_dump(jpc_dec_t *dec, FILE *out)
 			for (rlvlno = 0, rlvl = tcomp->rlvls; rlvlno <
 			  tcomp->numrlvls; ++rlvlno, ++rlvl) {
 fprintf(out, "RESOLUTION LEVEL %d\n", rlvlno);
-fprintf(out, "xs =%d, ys = %d, xe = %d, ye = %d, w = %d, h = %d\n",
+fprintf(out, "xs =%" PRIuFAST32 ", ys = %" PRIuFAST32 ", xe = %" PRIuFAST32 ", ye = %" PRIuFAST32 ", w = %" PRIuFAST32 ", h = %" PRIuFAST32 "\n",
   rlvl->xstart, rlvl->ystart, rlvl->xend, rlvl->yend, rlvl->xend -
   rlvl->xstart, rlvl->yend - rlvl->ystart);
 				for (bandno = 0, band = rlvl->bands;
 				  bandno < rlvl->numbands; ++bandno, ++band) {
 fprintf(out, "BAND %d\n", bandno);
-fprintf(out, "xs =%d, ys = %d, xe = %d, ye = %d, w = %d, h = %d\n",
+fprintf(out, "xs =%" PRIiFAST32 ", ys = %" PRIiFAST32 ", xe = %" PRIiFAST32 ", ye = %" PRIiFAST32 ", w = %" PRIiFAST32 ", h = %" PRIiFAST32 "\n",
   jas_seq2d_xstart(band->data), jas_seq2d_ystart(band->data), jas_seq2d_xend(band->data),
   jas_seq2d_yend(band->data), jas_seq2d_xend(band->data) - jas_seq2d_xstart(band->data),
   jas_seq2d_yend(band->data) - jas_seq2d_ystart(band->data));
@@ -2051,7 +2054,7 @@ fprintf(out, "xs =%d, ys = %d, xe = %d, ye = %d, w = %d, h = %d\n",
 					  prcno < rlvl->numprcs; ++prcno,
 					  ++prc) {
 fprintf(out, "CODE BLOCK GROUP %d\n", prcno);
-fprintf(out, "xs =%d, ys = %d, xe = %d, ye = %d, w = %d, h = %d\n",
+fprintf(out, "xs =%" PRIuFAST32 ", ys = %" PRIuFAST32 ", xe = %" PRIuFAST32 ", ye = %" PRIuFAST32 ", w = %" PRIuFAST32 ", h = %" PRIuFAST32 "\n",
   prc->xstart, prc->ystart, prc->xend, prc->yend, prc->xend -
   prc->xstart, prc->yend - prc->ystart);
 						for (cblkno = 0, cblk =
@@ -2059,7 +2062,7 @@ fprintf(out, "xs =%d, ys = %d, xe = %d, ye = %d, w = %d, h = %d\n",
 						  prc->numcblks; ++cblkno,
 						  ++cblk) {
 fprintf(out, "CODE BLOCK %d\n", cblkno);
-fprintf(out, "xs =%d, ys = %d, xe = %d, ye = %d, w = %d, h = %d\n",
+fprintf(out, "xs =%" PRIiFAST32 ", ys = %" PRIiFAST32 ", xe = %" PRIiFAST32 ", ye = %" PRIiFAST32 ", w = %" PRIiFAST32 ", h = %" PRIiFAST32 "\n",
   jas_seq2d_xstart(cblk->data), jas_seq2d_ystart(cblk->data), jas_seq2d_xend(cblk->data),
   jas_seq2d_yend(cblk->data), jas_seq2d_xend(cblk->data) - jas_seq2d_xstart(cblk->data),
   jas_seq2d_yend(cblk->data) - jas_seq2d_ystart(cblk->data));

--- a/src/libjasper/jpc/jpc_enc.c
+++ b/src/libjasper/jpc/jpc_enc.c
@@ -148,8 +148,10 @@ void jpc_enc_dump(jpc_enc_t *enc);
 int dump_passes(jpc_enc_pass_t *passes, int numpasses, jpc_enc_cblk_t *cblk);
 void calcrdslopes(jpc_enc_cblk_t *cblk);
 void dump_layeringinfo(jpc_enc_t *enc);
+/*
 static int jpc_calcssexp(jpc_fix_t stepsize);
 static int jpc_calcssmant(jpc_fix_t stepsize);
+*/
 void jpc_quantize(jas_matrix_t *data, jpc_fix_t stepsize);
 static int jpc_enc_encodemainhdr(jpc_enc_t *enc);
 static int jpc_enc_encodemainbody(jpc_enc_t *enc);
@@ -863,6 +865,7 @@ void jpc_enc_destroy(jpc_enc_t *enc)
 * Code.
 \******************************************************************************/
 
+/*
 static int jpc_calcssmant(jpc_fix_t stepsize)
 {
 	int n;
@@ -883,6 +886,7 @@ static int jpc_calcssexp(jpc_fix_t stepsize)
 {
 	return jpc_firstone(stepsize) - JPC_FIX_FRACBITS;
 }
+*/
 
 static int jpc_enc_encodemainhdr(jpc_enc_t *enc)
 {
@@ -897,7 +901,7 @@ long mainhdrlen;
 	jpc_enc_tccp_t *tccp;
 	uint_fast16_t cmptno;
 	jpc_tsfb_band_t bandinfos[JPC_MAXBANDS];
-	jpc_fix_t mctsynweight;
+	// jpc_fix_t mctsynweight;
 	jpc_enc_tcp_t *tcp;
 	jpc_tsfb_t *tsfb;
 	jpc_tsfb_band_t *bandinfo;
@@ -992,7 +996,7 @@ startoff = jas_stream_getrwcount(enc->out);
 		jpc_tsfb_getbands(tsfb, 0, 0, 1 << tccp->maxrlvls, 1 << tccp->maxrlvls,
 		  bandinfos);
 		jpc_tsfb_destroy(tsfb);
-		mctsynweight = jpc_mct_getsynweight(tcp->mctid, cmptno);
+		// mctsynweight = jpc_mct_getsynweight(tcp->mctid, cmptno);
 		numbands = 3 * tccp->maxrlvls - 2;
 		for (bandno = 0, bandinfo = bandinfos; bandno < numbands;
 		  ++bandno, ++bandinfo) {
@@ -1096,8 +1100,8 @@ startoff = jas_stream_getrwcount(enc->out);
 static int jpc_enc_encodemainbody(jpc_enc_t *enc)
 {
 	int tileno;
-	int tilex;
-	int tiley;
+	// int tilex;
+	// int tiley;
 	int i;
 	jpc_sot_t *sot;
 	jpc_enc_tcmpt_t *comp;
@@ -1111,7 +1115,7 @@ static int jpc_enc_encodemainbody(jpc_enc_t *enc)
 	int adjust;
 	int j;
 	int absbandno;
-	long numbytes;
+	// long numbytes;
 	long tilehdrlen;
 	long tilelen;
 	jpc_enc_tile_t *tile;
@@ -1134,11 +1138,11 @@ int numgbits;
 	cp = enc->cp;
 
 	/* Avoid compile warnings. */
-	numbytes = 0;
+	// numbytes = 0;
 
 	for (tileno = 0; tileno < JAS_CAST(int, cp->numtiles); ++tileno) {
-		tilex = tileno % cp->numhtiles;
-		tiley = tileno / cp->numhtiles;
+		// tilex = tileno % cp->numhtiles;
+		// tiley = tileno / cp->numhtiles;
 
 		if (!(enc->curtile = jpc_enc_tile_create(enc->cp, enc->image, tileno))) {
 			abort();

--- a/src/libjasper/jpc/jpc_mqdec.c
+++ b/src/libjasper/jpc/jpc_mqdec.c
@@ -74,6 +74,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <inttypes.h>
 
 #include "jasper/jas_types.h"
 #include "jasper/jas_malloc.h"
@@ -300,7 +301,7 @@ void jpc_mqdec_dump(jpc_mqdec_t *mqdec, FILE *out)
 	fprintf(out, "MQDEC A = %08lx, C = %08lx, CT=%08lx, ",
 	  (unsigned long) mqdec->areg, (unsigned long) mqdec->creg,
 	  (unsigned long) mqdec->ctreg);
-	fprintf(out, "CTX = %d, ", mqdec->curctx - mqdec->ctxs);
-	fprintf(out, "IND %d, MPS %d, QEVAL %x\n", *mqdec->curctx -
+	fprintf(out, "CTX = %" PRIdPTR ", ", mqdec->curctx - mqdec->ctxs);
+	fprintf(out, "IND %" PRIdPTR ", MPS %d, QEVAL %" PRIuFAST16 "\n", *mqdec->curctx -
 	  jpc_mqstates, (*mqdec->curctx)->mps, (*mqdec->curctx)->qeval);
 }

--- a/src/libjasper/jpc/jpc_mqenc.c
+++ b/src/libjasper/jpc/jpc_mqenc.c
@@ -73,6 +73,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #include "jasper/jas_stream.h"
 #include "jasper/jas_malloc.h"
@@ -383,9 +384,9 @@ static void jpc_mqenc_setbits(jpc_mqenc_t *mqenc)
 
 int jpc_mqenc_dump(jpc_mqenc_t *mqenc, FILE *out)
 {
-	fprintf(out, "AREG = %08x, CREG = %08x, CTREG = %d\n",
+	fprintf(out, "AREG = %08" PRIuFAST32 ", CREG = %08" PRIuFAST32 ", CTREG = %" PRIuFAST32 "\n",
 	  mqenc->areg, mqenc->creg, mqenc->ctreg);
-	fprintf(out, "IND = %02d, MPS = %d, QEVAL = %04x\n",
+	fprintf(out, "IND = %02" PRIdPTR ", MPS = %d, QEVAL = %04" PRIuFAST16 "\n",
 	  *mqenc->curctx - jpc_mqstates, (*mqenc->curctx)->mps,
 	  (*mqenc->curctx)->qeval);
 	return 0;

--- a/src/libjasper/jpc/jpc_t1dec.c
+++ b/src/libjasper/jpc/jpc_t1dec.c
@@ -78,6 +78,7 @@
 #include "jasper/jas_fix.h"
 #include "jasper/jas_stream.h"
 #include "jasper/jas_math.h"
+#include "jasper/jas_debug.h"
 
 #include "jpc_bs.h"
 #include "jpc_mqdec.h"

--- a/src/libjasper/jpc/jpc_tsfb.c
+++ b/src/libjasper/jpc/jpc_tsfb.c
@@ -85,6 +85,10 @@
 void jpc_tsfb_getbands2(jpc_tsfb_t *tsfb, int locxstart, int locystart,
   int xstart, int ystart, int xend, int yend, jpc_tsfb_band_t **bands,
   int numlvls);
+int jpc_tsfb_analyze2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
+  int width, int height, int stride, int numlvls);
+int jpc_tsfb_synthesize2(jpc_tsfb_t *tsfb, int *a, int xstart, int ystart,
+  int width, int height, int stride, int numlvls);
 
 /******************************************************************************\
 *

--- a/src/libjasper/mif/mif_cod.c
+++ b/src/libjasper/mif/mif_cod.c
@@ -70,6 +70,7 @@
 #include "jasper/jas_image.h"
 #include "jasper/jas_string.h"
 #include "jasper/jas_malloc.h"
+#include "jasper/jas_debug.h"
 
 #include "mif_cod.h"
 

--- a/src/libjasper/pgx/pgx_cod.c
+++ b/src/libjasper/pgx/pgx_cod.c
@@ -63,6 +63,8 @@
 * Includes.
 \******************************************************************************/
 
+#include <inttypes.h>
+
 #include "pgx_cod.h"
 
 /******************************************************************************\
@@ -71,7 +73,7 @@
 
 void pgx_dumphdr(FILE *out, pgx_hdr_t *hdr)
 {
-	fprintf(out, "byteorder=%s sgnd=%s prec=%d width=%d height=%d\n",
+	fprintf(out, "byteorder=%s sgnd=%s prec=%" PRIuFAST32 " width=%" PRIuFAST32 " height=%" PRIuFAST32 "\n",
 	  hdr->bigendian ? "bigendian" : "littleendian",
 	  hdr->sgnd ? "signed" : "unsigned",
 	  hdr->prec, hdr->width, hdr->height);

--- a/src/libjasper/pnm/pnm_dec.c
+++ b/src/libjasper/pnm/pnm_dec.c
@@ -79,6 +79,7 @@
 #include "jasper/jas_types.h"
 #include "jasper/jas_stream.h"
 #include "jasper/jas_image.h"
+#include "jasper/jas_debug.h"
 
 #include "pnm_cod.h"
 


### PR DESCRIPTION
Hi @mdadams 
I've fixed multiple smaller issues.
There are still some remaining issues, for instance:
```
../../../../src/libjasper/include/jasper/jas_seq.h:259:2: warning: passing argument 2 of ‘jpc_tsfb_analyze2’ from incompatible pointer type [-Wincompatible-pointer-types]
  (jas_matrix_getref(s, (y) - (s)->ystart_, (x) - (s)->xstart_))
```
I think fixing these issues is very desirable, as passing incompatible pointer types is undefined behaviour and might break in the future.