### PR TITLE
Request support for C99 at configure time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ Makefile.in
 # ./src/libjasper/include/jasper directory
 /src/libjasper/include/jasper/jas_config.h
 /src/libjasper/include/jasper/jas_config.h.in
+/src/libjasper/include/jasper/jas_config.h.in~
 /src/libjasper/include/jasper/stamp-h1

--- a/configure.ac
+++ b/configure.ac
@@ -151,7 +151,7 @@ AH_BOTTOM([
 ############################################################
 
 AC_PROG_CC
-#AC_PROG_CC_C11
+AC_PROG_CC_C99
 AC_PROG_INSTALL
 # AC_PROG_AWK
 # AC_PROG_CPP


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=598418
Old compilers (GCC 4.9 and below) will otherwise fail with
the new C++/C99-style comments in the source code.