### PR TITLE
Try -std=c99 if -std=c11 doesn't work

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -168,8 +168,9 @@ AC_PROG_CC
 # In the ideal world, AC_PROG_CC_C11 would exist and work.
 #AC_PROG_CC_C11
 
-# Attempt to enable C11 support if available.
-AX_CHECK_COMPILE_FLAG([-std=c11], [AX_APPEND_FLAG([-std=c11])], [])
+# Attempt to enable C11 support if available, and if not, try C99.
+AX_CHECK_COMPILE_FLAG([-std=c11], [AX_APPEND_FLAG([-std=c11])],
+[AX_CHECK_COMPILE_FLAG([-std=c99], [AX_APPEND_FLAG([-std=c99])])])
 
 AC_PROG_INSTALL
 # AC_PROG_AWK


### PR DESCRIPTION
C99 features are being used, so -pedantic-errors will make the build fail if the compiler doesn't default to C99 or later.
