### PR TITLE
CMakeLists.txt: only change RPATH when building for shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,8 @@ endif()
 
 ################################################################################
 
+if (JAS_ENABLE_SHARED)
+
 # use, i.e. don't skip the full RPATH for the build tree
 SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
 
@@ -212,6 +214,8 @@ LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib"
 IF("${isSystemDir}" STREQUAL "-1")
    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 ENDIF("${isSystemDir}" STREQUAL "-1")
+
+endif (JAS_ENABLE_SHARED)
 
 ################################################################################
 


### PR DESCRIPTION
When doing static-only builds (-DJAS_ENABLE_SHARED=OFF) the install
process fails due to an invalid RPATH:

...............................................................
CMake Error at src/appl/cmake_install.cmake:45 (file):
  file RPATH_CHANGE could not write new RPATH:

    /usr/lib

  to the file:

    /br/output/host/usr/xtensa-buildroot-linux-uclibc/sysroot/usr/bin/jasper

  No valid ELF RPATH or RUNPATH entry exists in the file;
Call Stack (most recent call first):
  cmake_install.cmake:42 (include)
...............................................................

RPATH shouldn't be changed when doing static-only builds.

Signed-off-by: Vicente Olivert Riera <Vincent.Riera@imgtec.com>