### PR TITLE
Make .pc file more Autotools-idiomatic

### DIFF
--- a/build/jasper.pc.in
+++ b/build/jasper.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: JasPer
 Description: Image Processing/Coding Tool Kit with JPEG-2000 Support


### PR DESCRIPTION
Hey @mdadams 
I've made the `.pc` file slightly more idiomatic and humanly readable. The current file for instance:
```
prefix=/usr
exec_prefix=/usr
libdir=/usr/lib
includedir=/usr/include
```
compared to say glib-2.0 (https://github.com/GNOME/glib/blob/master/glib-2.0.pc.in):
```
prefix=/usr
exec_prefix=${prefix}
libdir=/usr/lib64
includedir=${prefix}/include
```
Given that the `GNUInstallDirs` module does not have an `exec_prefix` analogue, I suggest recycling the normal prefix (which is what 99.9% of distros do anyways). The main advantage is that it makes it easier to read and potentially inserts only one massive path (`@CMAKE_INSTALL_PREFIX@`) into the .pc file, instead of inserting it 4 times.

Also, please make another release after (possibly) merging this PR.