### PR TITLE
Fix include flag ordering

### DIFF
--- a/src/libjasper/CMakeLists.txt
+++ b/src/libjasper/CMakeLists.txt
@@ -131,7 +131,7 @@ add_library(libjasper ${libjasper_type}
 	${libjasper_ras_sources}
 )
 
-target_include_directories(libjasper PUBLIC 
+target_include_directories(libjasper BEFORE PUBLIC
 	"${CMAKE_CURRENT_BINARY_DIR}/include"
 	"${CMAKE_CURRENT_SOURCE_DIR}/include"
 )


### PR DESCRIPTION
It is very important that the include dirs in the jasper source tree come
before the ones for external libraries in the compiler command. Otherwise
if you have e.g. libjpeg installed in the same prefix as an older version
of jasper, and you compile with:
-I/install/prefix/include -I/path/to/src/libjasper/include
then the headers for the old version will be found instead of those for
the version being built, which can result in compile failures and who
knows what other more subtle problems.

This change makes the order:
-I/path/to/src/libjasper/include -I/install/prefix/include
which will find the correct headers.