### PR TITLE
Disable C++ compiler check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 2.8.11)
 
-project(JasPer)
+project(JasPer C)
 
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/build/cmake/modules/")


### PR DESCRIPTION
jasper does not use C++ code. Allow use of toolchains without C++ support.