### PR TITLE
Use full CMake paths in pkg-config template

### DIFF
--- a/build/jasper.pc.in
+++ b/build/jasper.pc.in
@@ -1,7 +1,5 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: JasPer
 Description: Image Processing/Coding Tool Kit with JPEG-2000 Support


### PR DESCRIPTION
Using full paths is more versatile. The current solution
breaks when specifying an absolute path for `CMAKE_INSTALL_INCLUDEDIR`
which is an otherwise supported option by CMake's `GNUInstallDirs`.
CMake does not support Autoconf-style `${prefix}`-pseudo variables,
hence trying to emulate the behaviour gains us nothing and breaks
providing absolute paths to `CMAKE_INSTALL_LIBDIR`.