### PR TITLE
Avoid duplicate lib prefix in cmake

### DIFF
--- a/src/libjasper/CMakeLists.txt
+++ b/src/libjasper/CMakeLists.txt
@@ -131,6 +131,9 @@ add_library(libjasper ${libjasper_type}
 	${libjasper_ras_sources}
 )
 
+# avoid duplicate "lib" prefix
+set_target_properties(libjasper PROPERTIES OUTPUT_NAME "jasper")
+
 # The JasPer include directories in the source and build tree must be included
 # before any other directories that may contain the include directory for an
 # already installed version of the JasPer library.


### PR DESCRIPTION
Else a liblibjasper.* is built instead of just libjasper.* preventing use of -ljasper linking option