### PR TITLE
Filename buffer overflow fix

### DIFF
--- a/src/libjasper/include/jasper/jas_stream.h
+++ b/src/libjasper/include/jasper/jas_stream.h
@@ -78,6 +78,7 @@
 #include <jasper/jas_config.h>
 
 #include <stdio.h>
+#include <limits.h>
 #if defined(JAS_HAVE_FCNTL_H)
 #include <fcntl.h>
 #endif
@@ -98,6 +99,12 @@ extern "C" {
 /* On most UNIX systems, we probably need to define O_BINARY ourselves. */
 #ifndef O_BINARY
 #define O_BINARY	0
+#endif
+
+#ifdef PATH_MAX
+#define JAS_PATH_MAX PATH_MAX
+#else
+#define JAS_PATH_MAX 4096
 #endif
 
 /*
@@ -252,7 +259,7 @@ typedef struct {
 typedef struct {
 	int fd;
 	int flags;
-	char pathname[L_tmpnam + 1];
+	char pathname[JAS_PATH_MAX + 1];
 } jas_stream_fileobj_t;
 
 #define	JAS_STREAM_FILEOBJ_DELONCLOSE	0x01


### PR DESCRIPTION
Hi,

This patch is coming from Debian (and originally from ghostscript):

Description: Filename buffer overflow fix
 Increase the size of a temp file buffer to accomodate larger path names
 needed for mkstemp (instead of tmpnam that was used originally).
 Thanks to Henk Jan Priester for the patch.
Bug: https://bugs.ghostscript.com/show_bug.cgi?id=692574
Bug-Debian: https://bugs.debian.org/649833

Regards, Adam.