### PR TITLE
jpc_cs: limit the tile size

### DIFF
--- a/src/libjasper/jpc/jpc_cs.c
+++ b/src/libjasper/jpc/jpc_cs.c
@@ -514,6 +514,10 @@ static int jpc_siz_getparms(jpc_ms_t *ms, jpc_cstate_t *cstate,
 		jas_eprintf("tile cannot have zero area\n");
 		goto error;
 	}
+	if (siz->tilewidth > 16384 || siz->tileheight > 16384) {
+		jas_eprintf("tile cannot have zero area\n");
+		goto error;
+	}
 	if (!siz->numcomps || siz->numcomps > 16384) {
 		jas_eprintf("number of components not in permissible range\n");
 		goto error;


### PR DESCRIPTION
It is dangerous to accept arbitrary tile sizes, because the tile size
is used for memory allocations in jas_seq2d_create(), and can allow
attackers to exhaust a victim's memory.

Even worse, the size passed to the allocator is subject to an integer
overflow in jpc_dec_process_siz():

  tile->xend = JAS_MIN(dec->tilexoff + (htileno + 1) * dec->tilewidth, dec->xend);

Usually, JPEG2000 tiles are around 256 pixels wide and tall.  Limiting
these to a maximum of 16384 pixels appears reasonable.  It still
allows allocating vast amounts of memory, but puts a ceiling which can
be handled by most machines.