### PR TITLE
CMakeLists: Fix project() call to work with CMake 2.x and 3.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required (VERSION 2.8.11)
 
-project(JasPer LANGUAGES C)
+if (CMAKE_MAJOR_VERSION LESS 3)
+    project(JasPer C)
+else()
+    project(JasPer LANGUAGES C)
+endif()
 
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/build/cmake/modules/")


### PR DESCRIPTION
Changes the use of the CMake `project` command with language specifiers to work with both CMake 2.x and 3.x (fixes #135).

Prior to 3.x, the `project` command did not take a `LANGUAGES` keyword, so if you try to build jasper with 2.8, it thinks `LANGUAGES` is an actual language name.

As far as I can tell, the best approach would be to switch the usage of the `project` command based on `CMAKE_MAJOR_VERSION`, which I have done in this PR.