### PR TITLE
Increase JAS_DEC_DEFAULT_MAX_SAMPLES

### DIFF
--- a/src/libjasper/include/jasper/jas_config.h.in
+++ b/src/libjasper/include/jasper/jas_config.h.in
@@ -61,7 +61,7 @@
 #endif
 
 #if !defined(JAS_DEC_DEFAULT_MAX_SAMPLES)
-#define JAS_DEC_DEFAULT_MAX_SAMPLES (64 * ((size_t) 1048576))
+#define JAS_DEC_DEFAULT_MAX_SAMPLES (1024 * ((size_t) 1048576))
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)


### PR DESCRIPTION
Change multiplier from 64 to 1024, to allow for decoding / identifying larger .jp2 / JPEG 2000 files (~200MB or larger)

JJW
