### PR TITLE
Check data in jas_image

### DIFF
--- a/src/libjasper/base/jas_image.c
+++ b/src/libjasper/base/jas_image.c
@@ -491,6 +491,10 @@ int jas_image_readcmpt(jas_image_t *image, int cmptno, jas_image_coord_t x,
 	  image, cmptno, JAS_CAST(long, x), JAS_CAST(long, y),
 	  JAS_CAST(long, width), JAS_CAST(long, height), data));
 
+	if(data == NULL) {
+		return -1;
+	}
+
 	if (cmptno < 0 || cmptno >= image->numcmpts_) {
 		return -1;
 	}


### PR DESCRIPTION
Regarding CVE-2018-19539.
Fix by Markus Koschany <apo@debian.org>.
From https://gist.github.com/apoleon/7c0f3a0c28437c18fee8a51b1aa16164.