### PR TITLE
Check for NULL pointer in jp2_decode

### DIFF
--- a/src/libjasper/jp2/jp2_dec.c
+++ b/src/libjasper/jp2/jp2_dec.c
@@ -414,8 +414,12 @@ jas_image_t *jp2_decode(jas_stream_t *in, const char *optstr)
 		}
 	} else {
 		for (i = 0; i < dec->numchans; ++i) {
+			if(jp2_getct(jas_image_clrspc(dec->image), 0, i + 1) == NULL) {
+				jas_eprintf("error: invalid CT\n");
+				goto error;
+			}
 			jas_image_setcmpttype(dec->image, dec->chantocmptlut[i],
-			  jp2_getct(jas_image_clrspc(dec->image), 0, i + 1));
+			jp2_getct(jas_image_clrspc(dec->image), 0, i + 1));
 		}
 	}
 


### PR DESCRIPTION
Regards CVE-2018-19542.
Regards https://github.com/mdadams/jasper/issues/182.

Adapted fix from Markus Koschany <apo@debian.org>.
From https://gist.github.com/apoleon/701d7db34d63faa16463935b1465c74e