### PR TITLE
jas_image: Check number of lutents

### DIFF
--- a/src/libjasper/base/jas_image.c
+++ b/src/libjasper/base/jas_image.c
@@ -979,6 +979,10 @@ int jas_image_depalettize(jas_image_t *image, int cmptno, int numlutents,
 	cmptparms.prec = JAS_IMAGE_CDT_GETPREC(dtype);
 	cmptparms.sgnd = JAS_IMAGE_CDT_GETSGND(dtype);
 
+	if (numlutents < 1) {
+		return -1;
+	}
+
 	if (jas_image_addcmpt(image, newcmptno, &cmptparms)) {
 		return -1;
 	}


### PR DESCRIPTION
The index v of lutents[v] will be negative if numlutents is smaller than 1.
This causes the heap-based buffer overflow because the lutents[] starts at 0.

Regards CVE-2018-19541.
Regards #182 bug#1
Fix by Markus Koschany apo@debian.org.
From https://gist.github.com/apoleon/3e9d4e86c51d16c7e551a1cc538528b9